### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/javahippie/clj-groups.png?label=ready&title=Ready)](https://waffle.io/javahippie/clj-groups)
 # clj-groups
 
 [![Build Status](https://travis-ci.org/javahippie/clj-groups.svg?branch=master)](https://travis-ci.org/javahippie/clj-groups)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/javahippie/clj-groups

This was requested by a real person (user javahippie) on waffle.io, we're not trying to spam you.